### PR TITLE
Use Alternative Files If Primary Are Not Returned

### DIFF
--- a/spotify_aac_downloader/spotify_aac_downloader.py
+++ b/spotify_aac_downloader/spotify_aac_downloader.py
@@ -107,7 +107,8 @@ class SpotifyAacDownloader:
 
 
     def get_file_id(self, metadata):
-        return next(i["file_id"] for i in metadata["file"] if i["format"] == self.audio_quality)
+        audio_files = metadata.get("file", metadata["alternative"][0]["file"])
+        return next(i["file_id"] for i in audio_files if i["format"] == self.audio_quality)
     
 
     def get_pssh(self, file_id):


### PR DESCRIPTION
![](https://media.tenor.com/7d8Ymi0g61wAAAAd/plan-a-didnt-work-grace.gif)

## Description
Howdy! I just got this set up today/yesterday and ran into an issue with a number of songs where for some reason it would fail to download specific songs, or specific versions of them.
Enabling the `-e` debug flag (super useful btw, thanks for including that) allowed me to track it down via this message:
```
  File "C:\Users\User\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\spotify_aac_downloader\spotify_aac_downloader.py", line 110, in get_file_id
    return next(i["file_id"] for i in metadata["file"] if i["format"] == self.audio_quality)
                                      ~~~~~~~~^^^^^^^^
KeyError: 'file'
Done (1 error(s))
```

After digging into it a little, it looks like the manifest data returned was not always returning the `file` object/dictionary in the main manifest and would sometimes contain an `alternative` array instead. By using this minor tweak in the code, i was able to download a full 48 song test playlist that was previously failing to download 17 of the songs (because of the above error).

## Notes
This was tested with the `-p` flag (high quality downloads) and appears to work reliably.