### PR TITLE
Added --use-queue-index-for-track and --directly-to-output flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ spotify-web-downloader can be configured using the command line arguments or the
 | `--template-folder-music-video` / `template_folder_music_video` | Template of the music video folders as a format string.                      | `{artist}/Unknown Album`                     |
 | `--template-file-music-video` / `template_file_music_video`     | Template of the music video files as a format string.                        | `{title}`                                    |
 | `--download-mode-video` / `download_mode_video`                 | Download mode for videos.                                                    | `ytdlp`                                      |
+| `--use-queue-index-for-track`, `-qit` / `use_queue_index_for_track`| Use the order in which the tracks are downloaded to determine the track number (usefull for downloading playlists).   | `false`                                      |
+| `--directly-to-output`, `-do` / `directly_to_output`                 | Download straight to specified output folder, or to `./Spotify/{track}` if not specified (usefull for downloading playlists). | `false`                                      |
 | `--no-config-file`, `-n` / -                                    | Do not use a config file.                                                    | `false`                                      |
 
 

--- a/spotify_web_downloader/cli.py
+++ b/spotify_web_downloader/cli.py
@@ -261,6 +261,20 @@ def load_config_file(
     default=downloader_music_video_sig.parameters["download_mode"].default,
     help="Download mode for videos.",
 )
+@click.option(
+    "--use-queue-index-for-track",
+    "-qit",
+    is_flag=True,
+    default=False,
+    help="Use the order in which the tracks are downloaded to determine the track number (usefull for downloading playlists).",
+)
+@click.option(
+    "--directly-to-output",
+    "-do",
+    is_flag=True,
+    default=False,
+    help="Download straight to specified output folder, or to ./Spotify/{track} if not specified (usefull for downloading playlists).",
+)
 # This option should always be last
 @click.option(
     "--no-config-file",
@@ -302,6 +316,8 @@ def main(
     template_folder_music_video: str,
     template_file_music_video: str,
     download_mode_video: DownloadModeVideo,
+    use_queue_index_for_track: bool,
+    directly_to_output: bool,
     no_config_file: bool,
 ) -> None:
     logging.basicConfig(
@@ -443,7 +459,11 @@ def main(
                         track_credits,
                         lyrics.unsynced,
                     )
-                    final_path = downloader_song.get_final_path(tags)
+
+                    if(use_queue_index_for_track):
+                        tags["track"] = queue_index
+                        
+                    final_path = downloader_song.get_final_path(tags, directly_to_output=directly_to_output)
                     lrc_path = downloader_song.get_lrc_path(final_path)
                     cover_path = downloader_song.get_cover_path(final_path)
                     cover_url = downloader.get_cover_url(metadata_gid, "LARGE")

--- a/spotify_web_downloader/cli.py
+++ b/spotify_web_downloader/cli.py
@@ -462,6 +462,8 @@ def main(
 
                     if(use_queue_index_for_track):
                         tags["track"] = queue_index
+                        tags["disc"] = 1
+                        tags["disc_total"] = 1
                         
                     final_path = downloader_song.get_final_path(tags, directly_to_output=directly_to_output)
                     lrc_path = downloader_song.get_lrc_path(final_path)

--- a/spotify_web_downloader/downloader_song.py
+++ b/spotify_web_downloader/downloader_song.py
@@ -33,7 +33,7 @@ class DownloaderSong:
     def _set_codec(self):
         self.codec = "MP4_256" if self.premium_quality else "MP4_128"
 
-    def get_final_path(self, tags: dict) -> Path:
+    def get_final_path(self, tags: dict, directly_to_output: bool = False) -> Path:
         final_path_folder = (
             self.template_folder_compilation.split("/")
             if tags["compilation"]
@@ -57,6 +57,10 @@ class DownloaderSong:
             )
             + ".m4a"
         ]
+        if(directly_to_output):
+            return self.downloader.output_path.joinpath(
+                *final_path_file
+            )
         return self.downloader.output_path.joinpath(*final_path_folder).joinpath(
             *final_path_file
         )


### PR DESCRIPTION
Added two new flags:
- `--use-queue-index-for-track`
- `--directly-to-output flags`
(both documented in readme)

I added them because I really like this tool but it's not very good at downloading playlists. If you use both of these flags it makes playlist downloads much more manageable.

ex.  `spotify-web-downloader -o ./my_playlist_name --use-queue-index-for-track --directly-to-output https://open.spotify.com/playlist/{playlist-id}` will download all songs in the given playlist to a single directory, and use their position in the playlist as the track number.